### PR TITLE
When localised keyword doesnt exist in the list, return the original

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,11 +4,20 @@ import { Text } from 'react-native';
 let _localization = {};
 
 export function setLocalization(localization) {
-    _localization = localization;
+	if(_localization!= undefined){
+		_localization = localization;	
+	}
+    
 }
 
 export function translate(value) {
-    return _localization[value];
+	if(!_localization.hasOwnProperty(value))
+      {
+          return value;
+      }
+      else {
+          return _localization[value];
+      }
 }
 
 export const Translate = ({ value }) => (


### PR DESCRIPTION
When translation is not available we can return the original text Instead of null.